### PR TITLE
Makefiles are not intended to be executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env make
 #
 # number - print the English name of a number of any size
 #


### PR DESCRIPTION
Typing `make foo` is shorter than typing `./Makefile foo`