### PR TITLE
#!…make needs -f

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-#!/usr/bin/env make
+#!/usr/bin/env -S make -f
 #
 # number - print the English name of a number of any size
 #


### PR DESCRIPTION
Running `./Makefile foo` will actually run `/usr/bin/make Makefile foo`, which will attempt to update both `Makefile` and `foo`; this may or may not be what's wanted.

Use <code>-f <i>makefilename</i></code> to specify a makefile.

(Personally I'm not convinced that the Makefile should be executable at all; please accept #2 instead of this patch.)